### PR TITLE
Fixed get_code_region_around_line() boundary issue

### DIFF
--- a/app/search/search_utils.py
+++ b/app/search/search_utils.py
@@ -339,11 +339,11 @@ def get_code_region_around_line(
 
     # start and end should also be 1-based valid line numbers
     start = max(1, line_no - window_size)
-    end = min(len(file_content), line_no + window_size)
+    end = min(len(file_content) + 1, line_no + window_size)
     snippet = ""
     for i in range(start, end):
         if with_lineno:
             snippet += f"{i} {file_content[i - 1]}"
         else:
-            snippet += file_content[i]
+            snippet += file_content[i - 1]
     return snippet


### PR DESCRIPTION
 In the `get_code_region_around_line()` function, `line_no` is 1-based, so we need to ensure that the last valid line is included in the output.  
If `line_no + window_size` exceeds `len(file_content)`, the current implementation excludes the last line due to the exclusive nature of `range(start, end)`.  
To fix this issue, I added `1` to `len(file_content)`, ensuring that the last line is included.  


Additionally, `i` in `range(start, end)` is 1-based because `start` and `end` are derived from `line_no`, which follows 1-based indexing.  
Without adjusting the index in the `else` block, using `file_content[i]` would be off by one, potentially leading to an `IndexError` or retrieving the wrong lines.  
To fix this, I replaced `file_content[i]` with `file_content[i - 1]`
